### PR TITLE
Add missing flag `--recurse-submodules` to the docker-based installation instruction

### DIFF
--- a/Dockerfile_aarch64
+++ b/Dockerfile_aarch64
@@ -19,7 +19,6 @@ RUN mkdir -p build && cd build && cmake .. && make -j && make install
 
 # Build app
 WORKDIR /opt/app
-RUN . ~/.profile && mkdir -p build && cd build && cmake .. && make -j
 
 # Default CMD
 ENTRYPOINT ["/opt/app/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ make -j
 1.  Clone the repository.
 
 ```shell
-$ git clone git@github.com:tier4/trt-lightnet.git
+$ git clone --recurse-submodules git@github.com:tier4/trt-lightnet.git
 $ cd trt-lightnet
 ```
 


### PR DESCRIPTION
Just an one-line editorial fix.

Need to add `--recurse-submodules` when cloning the repo, but the docker-based installation instruction misses the flag.