### PR TITLE
edit: add missing flag --recurse-submodules when cloning repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ $ make -j
 1.  Clone the repository.
 
 ```shell
-$ git clone git@github.com:tier4/trt-lightnet.git
+$ git clone --recurse-submodules git@github.com:tier4/trt-lightnet.git
 $ cd trt-lightnet
 ```
 


### PR DESCRIPTION
Just a one-line editorial fix.

The docker-based installation instruction misses adding `--recurse-submodules` when cloning repo.