### PR TITLE
fix: destroy sub_instance in destroy()

### DIFF
--- a/python/pylightnet/__init__.py
+++ b/python/pylightnet/__init__.py
@@ -386,6 +386,8 @@ class TrtLightnet:
 
     def destroy(self):
         self.lib.destroy_trt_lightnet(self.instance)
+        if hasattr(self, "sub_instance"):
+            self.lib.destroy_trt_lightnet(self.sub_instance)
 
     def infer_subnet_batches_from_bboxes(
         self,


### PR DESCRIPTION
## What?
- Destroy both `self.instance` and `self.sub_instance` (if exists) in the `self.destroy()` function. (pylightnet, TrtLightnet class)

## Why?
- Release GPU memory properly when `self.destroy()` runs.