### PR TITLE
fix: pin setuptools

### DIFF
--- a/.github/workflows/pylightnet-lint-and-test-ci.yaml
+++ b/.github/workflows/pylightnet-lint-and-test-ci.yaml
@@ -32,8 +32,8 @@ jobs:
         run: |
           mkdir -p ../build/_deps/cnpy-build  # dummy library paths
           touch ../build/_deps/cnpy-build/libcnpy.so ../build/liblightnetinfer.so
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install .[dev]
+          python -m pip install --upgrade pip "setuptools==80.9.0" wheel
+          python -m pip install .[dev] --no-build-isolation
 
       - name: Run the formatter
         working-directory: ./python

--- a/python/pylightnet/__init__.py
+++ b/python/pylightnet/__init__.py
@@ -1269,6 +1269,7 @@ def blur_sensitive_regions(image, bboxes, label_names, blur_kernel=(21, 21)):
 
     return blurred_image
 
+
 # Function to draw bounding boxes
 def draw_bboxes_on_image(image, bboxes, colormap, names, filled=False):
     for bbox in bboxes:


### PR DESCRIPTION
  Summary                                                                                                                                                                                                                            
                                                                                                                                                                                                                                     
  - CIが正常に完了するために、setuptoolsのバージョンを80.9.0に固定し、--no-build-isolationを追加                                                                                                                                                           
  - formatterを適用（空行の追加）                                                                                                                                                                                                    
                                                                                                                                                                                                                                     
  Test plan                                                                                                                                                                                                                          
                                                                                                                                                                                                                                     
  - pylightnet CI (lint, format, pytest) が通ることを確認 