### PR TITLE
Dev/jixin/tensorrt10.x support

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -27,10 +27,10 @@ except ImportError as e:
     print(
         "Error: Failed to import 'build' from setuptools.command.build\n"
         "\n"
-        "This package requires setuptools>=80.9.0,<81.0.0\n"
+        "This package requires setuptools>=80.9.0 (for the build backend).\n"
         "\n"
-        "Please upgrade setuptools to the required version:\n"
-        "  pip install 'setuptools>=80.9.0,<81.0.0'\n"
+        "Please upgrade setuptools:\n"
+        "  pip install -U 'setuptools>=80.9.0'\n"
         "\n"
         f"Original error: {e}",
         file=sys.stderr,
@@ -174,7 +174,8 @@ setup(
         "numpy<2.0",
     ],
     setup_requires=[
-        "setuptools>=80.9.0,<81.0.0",
+        # Upper bound removed: pip's build isolation often supplies setuptools 82+ (PEP 517).
+        "setuptools>=80.9.0",
     ],
     extras_require={
         "dev": [

--- a/src/tensorrt_common/tensorrt_common.cpp
+++ b/src/tensorrt_common/tensorrt_common.cpp
@@ -575,11 +575,11 @@ bool TrtCommon::buildEngineFromOnnx(
     for (std::int32_t i = 0; i < num_input_layers; i++) {
       const auto input = network->getInput(i);
       const auto input_dims = input->getDimensions();
-      const auto B = input_dims.d[0];
+      const auto B = input_dims.d[0];      
       if (B > 0) {
-        // Static first dim: skip setDimensions for this input. Do not overwrite batch_config_ —
-        // other inputs may still be dynamic and need the caller's min/opt/max.
-        continue;
+	// Fixed batch size
+	batch_config_ = {B, B, B};
+	continue;
       }
 
       nvinfer1::Dims min_input_dims{input_dims};

--- a/src/tensorrt_common/tensorrt_common.cpp
+++ b/src/tensorrt_common/tensorrt_common.cpp
@@ -575,11 +575,11 @@ bool TrtCommon::buildEngineFromOnnx(
     for (std::int32_t i = 0; i < num_input_layers; i++) {
       const auto input = network->getInput(i);
       const auto input_dims = input->getDimensions();
-      const auto B = input_dims.d[0];      
+      const auto B = input_dims.d[0];
       if (B > 0) {
-	// Fixed batch size
-	batch_config_ = {B, B, B};
-	continue;
+        // Static first dim: skip setDimensions for this input. Do not overwrite batch_config_ —
+        // other inputs may still be dynamic and need the caller's min/opt/max.
+        continue;
       }
 
       nvinfer1::Dims min_input_dims{input_dims};

--- a/src/tensorrt_lightnet/tensorrt_lightnet.cpp
+++ b/src/tensorrt_lightnet/tensorrt_lightnet.cpp
@@ -3470,47 +3470,45 @@ namespace tensorrt_lightnet
 
       // ===== Argmax path (int32, [H, W]) =====
       if (contain(name, "argmax")) {
-        if (
-          dataType != nvinfer1::DataType::kINT32
+        std::vector<std::vector<json::object_t>> annotations(colormap.size());
+        auto build_masks_from_argmax = [&](auto read_id_fn) {
+          for (int c = 1; c < static_cast<int>(colormap.size()); ++c) {  // skip background 0
+            cv::Mat mask = cv::Mat::zeros(outputH, outputW, CV_8UC1);
+
+            // Build binary mask for class c
+            for (int y = 0; y < outputH; ++y) {
+              uchar* row = mask.ptr<uchar>(y);
+              const int base = y * outputW;
+              for (int x = 0; x < outputW; ++x) {
+                const int id = read_id_fn(base + x);
+                if (id == c) {
+                  row[x] = 255;
+                }
+              }
+            }
+
+            // Extract polygons and append JSON
+            push_annotations_from_mask(mask, c, scaleX, scaleY, annotations);
+          }
+        };
+
 #if TRT_VER_NUM >= 10000
-          && dataType != nvinfer1::DataType::kINT64
-#endif
-        ) {
+        if (dataType == nvinfer1::DataType::kINT64) {
+          const int64_t* argmax64 = reinterpret_cast<const int64_t*>(output_h_.at(i - 1).get());
+          build_masks_from_argmax([&](const int idx) { return static_cast<int>(argmax64[idx]); });
+        } else if (dataType == nvinfer1::DataType::kINT32) {
+          const int* argmax32 = reinterpret_cast<const int*>(output_h_.at(i - 1).get());
+          build_masks_from_argmax([&](const int idx) { return argmax32[idx]; });
+        } else {
+          continue;
+        }
+#else
+        if (dataType != nvinfer1::DataType::kINT32) {
           continue;
         }
         const int* argmax32 = reinterpret_cast<const int*>(output_h_.at(i - 1).get());
-#if TRT_VER_NUM >= 10000
-        const int64_t* argmax64 = reinterpret_cast<const int64_t*>(output_h_.at(i - 1).get());
+        build_masks_from_argmax([&](const int idx) { return argmax32[idx]; });
 #endif
-
-        std::vector<std::vector<json::object_t>> annotations(colormap.size());
-
-        for (int c = 1; c < static_cast<int>(colormap.size()); ++c) {  // skip background 0
-          cv::Mat mask = cv::Mat::zeros(outputH, outputW, CV_8UC1);
-
-          // Build binary mask for class c
-          for (int y = 0; y < outputH; ++y) {
-            uchar* row = mask.ptr<uchar>(y);
-            const int base = y * outputW;
-            for (int x = 0; x < outputW; ++x) {
-              int id = 0;
-#if TRT_VER_NUM >= 10000
-              if (dataType == nvinfer1::DataType::kINT64) {
-                id = static_cast<int>(argmax64[base + x]);
-              } else
-#endif
-              {
-                id = argmax32[base + x];
-              }
-              if (id == c) {
-                row[x] = 255;
-              }
-            }
-          }
-
-          // Extract polygons and append JSON
-          push_annotations_from_mask(mask, c, scaleX, scaleY, annotations);
-        }
 
         // Append all annotations to the image-level container
         for (const auto& ann_set : annotations) {

--- a/src/tensorrt_lightnet/tensorrt_lightnet.cpp
+++ b/src/tensorrt_lightnet/tensorrt_lightnet.cpp
@@ -3468,62 +3468,57 @@ namespace tensorrt_lightnet
       const std::string name = trt_common_->getIOTensorName(i);
       const auto dataType = trt_common_->getBindingDataType(i);
 
-      // ===== Argmax path (int32/int64, [H, W]) =====
+      // ===== Argmax path (int32, [H, W]) =====
       if (contain(name, "argmax")) {
-        const bool is_argmax_i32 = (dataType == nvinfer1::DataType::kINT32);
+	if (dataType != nvinfer1::DataType::kINT32
 #if TRT_VER_NUM >= 10000
-        const bool is_argmax_i64 = (dataType == nvinfer1::DataType::kINT64);
-        if (!is_argmax_i32 && !is_argmax_i64) {
-          continue;
-        }
-#else
-        if (!is_argmax_i32) {
-          continue;
-        }
+            && dataType != nvinfer1::DataType::kINT64
 #endif
-        const int* argmax32 = reinterpret_cast<const int*>(output_h_.at(i - 1).get());
+            ) {
+	  continue;
+	}
+	const int* argmax32 = reinterpret_cast<const int*>(output_h_.at(i - 1).get());
 #if TRT_VER_NUM >= 10000
-        const int64_t* argmax64 =
-          is_argmax_i64 ? reinterpret_cast<const int64_t*>(output_h_.at(i - 1).get()) : nullptr;
+	const int64_t* argmax64 = reinterpret_cast<const int64_t*>(output_h_.at(i - 1).get());
 #endif
-        auto read_argmax_id = [&](const int idx) -> int {
+
+	std::vector<std::vector<json::object_t>> annotations(colormap.size());
+
+	for (int c = 1; c < static_cast<int>(colormap.size()); ++c) { // skip background 0
+	  cv::Mat mask = cv::Mat::zeros(outputH, outputW, CV_8UC1);
+
+	  // Build binary mask for class c
+	  for (int y = 0; y < outputH; ++y) {
+	    uchar* row = mask.ptr<uchar>(y);
+	    const int base = y * outputW;
+	    for (int x = 0; x < outputW; ++x) {
+	      int id = 0;
 #if TRT_VER_NUM >= 10000
-          if (is_argmax_i64) {
-            return static_cast<int>(argmax64[idx]);
-          }
+	      if (dataType == nvinfer1::DataType::kINT64) {
+		id = static_cast<int>(argmax64[base + x]);
+	      } else
 #endif
-          return argmax32[idx];
-        };
+	      {
+		id = argmax32[base + x];
+	      }
+	      if (id == c) {
+		row[x] = 255;
+	      }
+	    }
+	  }
 
-        std::vector<std::vector<json::object_t>> annotations(colormap.size());
+	  // Extract polygons and append JSON
+	  push_annotations_from_mask(mask, c, scaleX, scaleY, annotations);
+	}
 
-        for (int c = 1; c < static_cast<int>(colormap.size()); ++c) {  // skip background 0
-          cv::Mat mask = cv::Mat::zeros(outputH, outputW, CV_8UC1);
-
-          // Build binary mask for class c
-          for (int y = 0; y < outputH; ++y) {
-            uchar* row = mask.ptr<uchar>(y);
-            const int base = y * outputW;
-            for (int x = 0; x < outputW; ++x) {
-              const int id = read_argmax_id(base + x);
-              if (id == c) {
-                row[x] = 255;
-              }
-            }
-          }
-
-          // Extract polygons and append JSON
-          push_annotations_from_mask(mask, c, scaleX, scaleY, annotations);
-        }
-
-        // Append all annotations to the image-level container
-        for (const auto& ann_set : annotations) {
-          for (const auto& annotation : ann_set) {
-            if (!annotation.empty()) {
-              imageAnnotationsOrdered["annotations"].push_back(annotation);
-            }
-          }
-        }
+	// Append all annotations to the image-level container
+	for (const auto& ann_set : annotations) {
+	  for (const auto& annotation : ann_set) {
+	    if (!annotation.empty()) {
+	      imageAnnotationsOrdered["annotations"].push_back(annotation);
+	    }
+	  }
+	}
       }
 
       // ===== Softmax path (float32, [C, H, W] or [H, W, C]) =====

--- a/src/tensorrt_lightnet/tensorrt_lightnet.cpp
+++ b/src/tensorrt_lightnet/tensorrt_lightnet.cpp
@@ -98,6 +98,22 @@ std::vector<std::vector<cv::Point>> get_polygons( const cv::Mat &mask)
   return contours;
 }
 
+inline std::size_t get_dtype_size_bytes(nvinfer1::DataType dt)
+{
+  switch (dt) {
+    case nvinfer1::DataType::kFLOAT: return 4;
+    case nvinfer1::DataType::kHALF: return 2;
+    case nvinfer1::DataType::kINT8: return 1;
+    case nvinfer1::DataType::kINT32: return 4;
+#if TRT_VER_NUM >= 10000
+    case nvinfer1::DataType::kINT64: return 8;
+    case nvinfer1::DataType::kUINT8: return 1;
+    case nvinfer1::DataType::kBOOL: return 1;
+#endif
+    default: return 4;
+  }
+}
+
 void write_json_with_order(const json& j, const std::string& filename) {
   std::ofstream file(filename);
   if (!file) {
@@ -454,14 +470,19 @@ namespace tensorrt_lightnet
       }
       std::cout << name << " => " << dims.d[0] << "x" << dims.d[1] << "x" << dims.d[2] << "x" << dims.d[3] << " (" << trt_common_->dataType2String(dataType)  << ")" << std::endl;
 
-      // Calculate the tensor volume.
+      // Calculate tensor bytes based on binding datatype.
       const auto volume = std::accumulate(dims.d + 1, dims.d + dims.nbDims, 1, std::multiplies<int>());
+      const std::size_t bytes =
+        static_cast<std::size_t>(batch_size_) *
+        static_cast<std::size_t>(volume) *
+        get_dtype_size_bytes(dataType);
+      const std::size_t float_slots = (bytes + sizeof(float) - 1) / sizeof(float);
 
       if (i == 0) { // Input tensor
 	input_d_ = cuda_utils::make_unique<float[]>(batch_size_ * volume);
       } else { // Output tensors
-	output_d_.push_back(cuda_utils::make_unique<float[]>(batch_size_ * volume));
-	output_h_.push_back(cuda_utils::make_unique_host<float[]>(batch_size_ * volume, cudaHostAllocPortable));
+	output_d_.push_back(cuda_utils::make_unique<float[]>(float_slots));
+	output_h_.push_back(cuda_utils::make_unique_host<float[]>(float_slots, cudaHostAllocPortable));
       }
     }
   }
@@ -615,7 +636,15 @@ namespace tensorrt_lightnet
     for (int i = 1; i < trt_common_->getNbBindings(); i++) {
       const auto dims = trt_common_->getBindingDimensions(i);
       const auto output_size = std::accumulate(dims.d + 1, dims.d + dims.nbDims, 1, std::multiplies<int>());
-      CHECK_CUDA_ERROR(cudaMemcpyAsync(output_h_.at(i-1).get(), output_d_.at(i-1).get(), sizeof(float) * output_size, cudaMemcpyDeviceToHost, *stream_));
+      const auto dataType = trt_common_->getBindingDataType(i);
+      const std::size_t bytes =
+        static_cast<std::size_t>(output_size) * get_dtype_size_bytes(dataType);
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(
+        output_h_.at(i-1).get(),
+        output_d_.at(i-1).get(),
+        bytes,
+        cudaMemcpyDeviceToHost,
+        *stream_));
     }
     cudaStreamSynchronize(*stream_);
     return true;
@@ -652,7 +681,15 @@ namespace tensorrt_lightnet
       dims.d[0] = batchSize;
       auto output_size = std::accumulate(dims.d + 1, dims.d + dims.nbDims, 1, std::multiplies<int>());
       output_size *= batchSize;
-      CHECK_CUDA_ERROR(cudaMemcpyAsync(output_h_.at(i-1).get(), output_d_.at(i-1).get(), sizeof(float) * output_size, cudaMemcpyDeviceToHost, *stream_));
+      const auto dataType = trt_common_->getBindingDataType(i);
+      const std::size_t bytes =
+        static_cast<std::size_t>(output_size) * get_dtype_size_bytes(dataType);
+      CHECK_CUDA_ERROR(cudaMemcpyAsync(
+        output_h_.at(i-1).get(),
+        output_d_.at(i-1).get(),
+        bytes,
+        cudaMemcpyDeviceToHost,
+        *stream_));
     }
     cudaStreamSynchronize(*stream_);
     return true;
@@ -3429,10 +3466,21 @@ namespace tensorrt_lightnet
       }
 
       const std::string name = trt_common_->getIOTensorName(i);
+      const auto dataType = trt_common_->getBindingDataType(i);
 
       // ===== Argmax path (int32, [H, W]) =====
       if (contain(name, "argmax")) {
-	const int* argmax = reinterpret_cast<const int*>(output_h_.at(i - 1).get());
+	if (dataType != nvinfer1::DataType::kINT32
+#if TRT_VER_NUM >= 10000
+            && dataType != nvinfer1::DataType::kINT64
+#endif
+            ) {
+	  continue;
+	}
+	const int* argmax32 = reinterpret_cast<const int*>(output_h_.at(i - 1).get());
+#if TRT_VER_NUM >= 10000
+	const int64_t* argmax64 = reinterpret_cast<const int64_t*>(output_h_.at(i - 1).get());
+#endif
 
 	std::vector<std::vector<json::object_t>> annotations(colormap.size());
 
@@ -3444,7 +3492,15 @@ namespace tensorrt_lightnet
 	    uchar* row = mask.ptr<uchar>(y);
 	    const int base = y * outputW;
 	    for (int x = 0; x < outputW; ++x) {
-	      const int id = argmax[base + x];
+	      int id = 0;
+#if TRT_VER_NUM >= 10000
+	      if (dataType == nvinfer1::DataType::kINT64) {
+		id = static_cast<int>(argmax64[base + x]);
+	      } else
+#endif
+	      {
+		id = argmax32[base + x];
+	      }
 	      if (id == c) {
 		row[x] = 255;
 	      }

--- a/src/tensorrt_lightnet/tensorrt_lightnet.cpp
+++ b/src/tensorrt_lightnet/tensorrt_lightnet.cpp
@@ -3468,47 +3468,53 @@ namespace tensorrt_lightnet
       const std::string name = trt_common_->getIOTensorName(i);
       const auto dataType = trt_common_->getBindingDataType(i);
 
-      // ===== Argmax path (int32, [H, W]) =====
+      // ===== Argmax path (int32/int64, [H, W]) =====
       if (contain(name, "argmax")) {
-        std::vector<std::vector<json::object_t>> annotations(colormap.size());
-        auto build_masks_from_argmax = [&](auto read_id_fn) {
-          for (int c = 1; c < static_cast<int>(colormap.size()); ++c) {  // skip background 0
-            cv::Mat mask = cv::Mat::zeros(outputH, outputW, CV_8UC1);
-
-            // Build binary mask for class c
-            for (int y = 0; y < outputH; ++y) {
-              uchar* row = mask.ptr<uchar>(y);
-              const int base = y * outputW;
-              for (int x = 0; x < outputW; ++x) {
-                const int id = read_id_fn(base + x);
-                if (id == c) {
-                  row[x] = 255;
-                }
-              }
-            }
-
-            // Extract polygons and append JSON
-            push_annotations_from_mask(mask, c, scaleX, scaleY, annotations);
-          }
-        };
-
+        const bool is_argmax_i32 = (dataType == nvinfer1::DataType::kINT32);
 #if TRT_VER_NUM >= 10000
-        if (dataType == nvinfer1::DataType::kINT64) {
-          const int64_t* argmax64 = reinterpret_cast<const int64_t*>(output_h_.at(i - 1).get());
-          build_masks_from_argmax([&](const int idx) { return static_cast<int>(argmax64[idx]); });
-        } else if (dataType == nvinfer1::DataType::kINT32) {
-          const int* argmax32 = reinterpret_cast<const int*>(output_h_.at(i - 1).get());
-          build_masks_from_argmax([&](const int idx) { return argmax32[idx]; });
-        } else {
+        const bool is_argmax_i64 = (dataType == nvinfer1::DataType::kINT64);
+        if (!is_argmax_i32 && !is_argmax_i64) {
           continue;
         }
 #else
-        if (dataType != nvinfer1::DataType::kINT32) {
+        if (!is_argmax_i32) {
           continue;
         }
-        const int* argmax32 = reinterpret_cast<const int*>(output_h_.at(i - 1).get());
-        build_masks_from_argmax([&](const int idx) { return argmax32[idx]; });
 #endif
+        const int* argmax32 = reinterpret_cast<const int*>(output_h_.at(i - 1).get());
+#if TRT_VER_NUM >= 10000
+        const int64_t* argmax64 =
+          is_argmax_i64 ? reinterpret_cast<const int64_t*>(output_h_.at(i - 1).get()) : nullptr;
+#endif
+        auto read_argmax_id = [&](const int idx) -> int {
+#if TRT_VER_NUM >= 10000
+          if (is_argmax_i64) {
+            return static_cast<int>(argmax64[idx]);
+          }
+#endif
+          return argmax32[idx];
+        };
+
+        std::vector<std::vector<json::object_t>> annotations(colormap.size());
+
+        for (int c = 1; c < static_cast<int>(colormap.size()); ++c) {  // skip background 0
+          cv::Mat mask = cv::Mat::zeros(outputH, outputW, CV_8UC1);
+
+          // Build binary mask for class c
+          for (int y = 0; y < outputH; ++y) {
+            uchar* row = mask.ptr<uchar>(y);
+            const int base = y * outputW;
+            for (int x = 0; x < outputW; ++x) {
+              const int id = read_argmax_id(base + x);
+              if (id == c) {
+                row[x] = 255;
+              }
+            }
+          }
+
+          // Extract polygons and append JSON
+          push_annotations_from_mask(mask, c, scaleX, scaleY, annotations);
+        }
 
         // Append all annotations to the image-level container
         for (const auto& ann_set : annotations) {

--- a/src/tensorrt_lightnet/tensorrt_lightnet.cpp
+++ b/src/tensorrt_lightnet/tensorrt_lightnet.cpp
@@ -3470,55 +3470,56 @@ namespace tensorrt_lightnet
 
       // ===== Argmax path (int32, [H, W]) =====
       if (contain(name, "argmax")) {
-	if (dataType != nvinfer1::DataType::kINT32
+        if (
+          dataType != nvinfer1::DataType::kINT32
 #if TRT_VER_NUM >= 10000
-            && dataType != nvinfer1::DataType::kINT64
+          && dataType != nvinfer1::DataType::kINT64
 #endif
-            ) {
-	  continue;
-	}
-	const int* argmax32 = reinterpret_cast<const int*>(output_h_.at(i - 1).get());
+        ) {
+          continue;
+        }
+        const int* argmax32 = reinterpret_cast<const int*>(output_h_.at(i - 1).get());
 #if TRT_VER_NUM >= 10000
-	const int64_t* argmax64 = reinterpret_cast<const int64_t*>(output_h_.at(i - 1).get());
+        const int64_t* argmax64 = reinterpret_cast<const int64_t*>(output_h_.at(i - 1).get());
 #endif
 
-	std::vector<std::vector<json::object_t>> annotations(colormap.size());
+        std::vector<std::vector<json::object_t>> annotations(colormap.size());
 
-	for (int c = 1; c < static_cast<int>(colormap.size()); ++c) { // skip background 0
-	  cv::Mat mask = cv::Mat::zeros(outputH, outputW, CV_8UC1);
+        for (int c = 1; c < static_cast<int>(colormap.size()); ++c) {  // skip background 0
+          cv::Mat mask = cv::Mat::zeros(outputH, outputW, CV_8UC1);
 
-	  // Build binary mask for class c
-	  for (int y = 0; y < outputH; ++y) {
-	    uchar* row = mask.ptr<uchar>(y);
-	    const int base = y * outputW;
-	    for (int x = 0; x < outputW; ++x) {
-	      int id = 0;
+          // Build binary mask for class c
+          for (int y = 0; y < outputH; ++y) {
+            uchar* row = mask.ptr<uchar>(y);
+            const int base = y * outputW;
+            for (int x = 0; x < outputW; ++x) {
+              int id = 0;
 #if TRT_VER_NUM >= 10000
-	      if (dataType == nvinfer1::DataType::kINT64) {
-		id = static_cast<int>(argmax64[base + x]);
-	      } else
+              if (dataType == nvinfer1::DataType::kINT64) {
+                id = static_cast<int>(argmax64[base + x]);
+              } else
 #endif
-	      {
-		id = argmax32[base + x];
-	      }
-	      if (id == c) {
-		row[x] = 255;
-	      }
-	    }
-	  }
+              {
+                id = argmax32[base + x];
+              }
+              if (id == c) {
+                row[x] = 255;
+              }
+            }
+          }
 
-	  // Extract polygons and append JSON
-	  push_annotations_from_mask(mask, c, scaleX, scaleY, annotations);
-	}
+          // Extract polygons and append JSON
+          push_annotations_from_mask(mask, c, scaleX, scaleY, annotations);
+        }
 
-	// Append all annotations to the image-level container
-	for (const auto& ann_set : annotations) {
-	  for (const auto& annotation : ann_set) {
-	    if (!annotation.empty()) {
-	      imageAnnotationsOrdered["annotations"].push_back(annotation);
-	    }
-	  }
-	}
+        // Append all annotations to the image-level container
+        for (const auto& ann_set : annotations) {
+          for (const auto& annotation : ann_set) {
+            if (!annotation.empty()) {
+              imageAnnotationsOrdered["annotations"].push_back(annotation);
+            }
+          }
+        }
       }
 
       // ===== Softmax path (float32, [C, H, W] or [H, W, C]) =====


### PR DESCRIPTION
This PR refactors the trt-lightnet deployment pipeline to improve cross-version compatibility and modularize the core inference logic.

Key Changes:

* Fix the bug of dynamic batch
* Dynamically change the data copy size between host and device depending on the binding dtype
* Refactor the argmax process logic to support both TRT8 and TRT10 layer