### PR TITLE
fix(pylightnet): honor --first/--last so partial INT8 builds via the Python API

### DIFF
--- a/python/pylightnet/__init__.py
+++ b/python/pylightnet/__init__.py
@@ -828,6 +828,14 @@ def parse_build_config(config_dict):
     build_config.dla_core_id = -1
     build_config.quantize_first_layer = False
     build_config.quantize_last_layer = False
+    # Honor --first / --last from the pipeline .txt so that PARTIAL INT8 (first and
+    # last layers kept in higher precision) can be built via pylightnet. Without this,
+    # these flags are read only by the trt-lightnet CLI (config_parser.cpp) and ignored
+    # here, so --precision=int8 always builds FULL int8 regardless of --first/--last.
+    # Gated on precision==int8 so fp16/fp32 engine cache names are unaffected.
+    if str(config_dict.get("precision", "")).lower() == "int8":
+        build_config.quantize_first_layer = bool(config_dict.get("first", False))
+        build_config.quantize_last_layer = bool(config_dict.get("last", False))
     build_config.profile_per_layer = True
     build_config.clip_value = -1
     if "sparse" in config_dict:


### PR DESCRIPTION
## Summary
`parse_build_config()` in `python/pylightnet/__init__.py` hardcodes
`build_config.quantize_first_layer = False` and `quantize_last_layer = False` and never reads the
`first` / `last` values that `load_config()` already parses from the pipeline `.txt`. As a result,
any engine built through the Python API (`create_lightnet_from_config`) is **always FULL INT8** for
`--precision=int8`, regardless of `--first=true` / `--last=true`. Those flags are honored only by the
`trt-lightnet` **CLI** (`config_parser.cpp` → `get_first_flg` / `get_last_flg`), not by pylightnet.

## Motivation
**Partial INT8** — keeping the first and last layers in higher precision — is the recommended INT8
variant for this detector: it removes the FP32↔INT8 *reformat* overhead at the I/O boundaries and
preserves accuracy on small objects. Via the Python API it was **impossible to obtain**: users set
`--first/--last` in the `.txt`, saw no error, and silently got full INT8 (worse accuracy on small
plates/heads, and no speed benefit on the boundary reformats). This cost real debugging time on our
side before we traced it to the hardcoded `False`.

## Change
Read `first` / `last` from `config_dict` when `precision == "int8"`:

```python
if str(config_dict.get("precision", "")).lower() == "int8":
    build_config.quantize_first_layer = bool(config_dict.get("first", False))
    build_config.quantize_last_layer  = bool(config_dict.get("last", False))
```

Gated on `int8` so fp16/fp32 engine **cache names are unaffected** (the `-firstFP16-lastFP16` suffix is
only appended for int8 builds). **No native rebuild needed** — `liblightnetinfer.so` already applies
`setPrecision(kHALF)` from the `BuildConfig` struct; only the Python that fills the struct was wrong.

## Testing / verification
Built a large detector + subnet pipeline with `--precision=int8 --first=true --last=true`:
- **Before:** engine cache `…EntropyV2-int8-batch1.engine`; build log shows no `Set kHALF`.
- **After:** engine cache `…EntropyV2-int8-firstFP16-lastFP16-batch1.engine`; build log prints
  `Set kHALF in 001_convolutional` (first) … `210_convolutional` (last).
- Inference verified on real frames (all detection classes present); calibration table reuse unaffected.

## Risk / compatibility
Low. Behavior changes **only** for `precision == "int8"` configs that set `--first` / `--last` (which
were previously silently ignored). fp16/fp32 builds and existing engine caches are byte-for-byte
unaffected. No ABI/.so change.

## Checklist
- [x] Single-purpose change, gated on int8
- [x] No native/ABI change
- [x] Verified engine naming + `Set kHALF` log
- [ ] Maintainer: confirm desired default when `.txt` omits `first/last` (kept `False`)
