### PR TITLE
fix(subnet): guard non-CV_8UC3 crops + RAII scratch buffers in preprocess_gpu_batch

### DIFF
--- a/include/tensorrt_lightnet/tensorrt_lightnet.hpp
+++ b/include/tensorrt_lightnet/tensorrt_lightnet.hpp
@@ -1130,8 +1130,8 @@ public:
    * variable-size crops). Grown on demand; separate from h_img_/d_img_ to avoid disturbing
    * the single-image preprocess_gpu path.
    */
-  unsigned char* h_batch_ = nullptr;
-  unsigned char* d_batch_ = nullptr;
+  CudaUniquePtrHost<unsigned char[]> h_batch_;
+  CudaUniquePtr<unsigned char[]> d_batch_;
   size_t batch_buf_cap_ = 0;
 
   /**

--- a/src/tensorrt_lightnet/tensorrt_lightnet.cpp
+++ b/src/tensorrt_lightnet/tensorrt_lightnet.cpp
@@ -644,6 +644,14 @@ namespace tensorrt_lightnet
       preprocess(images);
       return;
     }
+    // Packing below assumes CV_8UC3 crops; fall back to the CPU path for anything else
+    // (infer_batches also accepts CV_8UC1, which preprocess() handles via cvtColor).
+    for (const auto & im : images) {
+      if (im.type() != CV_8UC3) {
+        preprocess(images);
+        return;
+      }
+    }
 
     const float norm = 1.0f / 255.0f;
     const size_t slot = static_cast<size_t>(inputC) * inputH * inputW; // floats per image (NCHW)
@@ -658,22 +666,20 @@ namespace tensorrt_lightnet
       total += static_cast<size_t>(src[b].rows) * src[b].cols * 3;
     }
 
-    // Grow scratch buffers on demand (pinned host + device), kept across calls.
+    // Grow scratch buffers on demand; reused across calls.
     if (total > batch_buf_cap_) {
-      if (h_batch_) { cudaFreeHost(h_batch_); h_batch_ = nullptr; }
-      if (d_batch_) { cudaFree(d_batch_);     d_batch_ = nullptr; }
-      CHECK_CUDA_ERROR(cudaMallocHost(reinterpret_cast<void**>(&h_batch_), total));
-      CHECK_CUDA_ERROR(cudaMalloc(reinterpret_cast<void**>(&d_batch_), total));
+      h_batch_ = cuda_utils::make_unique_host<unsigned char[]>(total, cudaHostAllocDefault);
+      d_batch_ = cuda_utils::make_unique<unsigned char[]>(total);
       batch_buf_cap_ = total;
     }
 
     // Pack crops into pinned host memory, then one async H->D copy (no per-crop race:
     // all host memcpys complete before the single copy; kernels read device-side after).
     for (size_t b = 0; b < batch_size; ++b) {
-      memcpy(h_batch_ + off[b], src[b].data,
+      memcpy(h_batch_.get() + off[b], src[b].data,
              static_cast<size_t>(src[b].rows) * src[b].cols * 3);
     }
-    CHECK_CUDA_ERROR(cudaMemcpyAsync(d_batch_, h_batch_, total,
+    CHECK_CUDA_ERROR(cudaMemcpyAsync(d_batch_.get(), h_batch_.get(), total,
                                      cudaMemcpyHostToDevice, *stream_));
 
     // Resize + normalize + BGR->RGB each crop into its disjoint NCHW batch slot.
@@ -681,7 +687,7 @@ namespace tensorrt_lightnet
     for (size_t b = 0; b < batch_size; ++b) {
       blobFromImageBilinearGpu(
           reinterpret_cast<float*>(input_d_.get()) + b * slot,
-          d_batch_ + off[b],
+          d_batch_.get() + off[b],
           inputW, inputH, inputC,
           src[b].cols, src[b].rows, 3,
           norm,


### PR DESCRIPTION
## Summary
Follow-up to **#20**, addressing two review comments on `preprocess_gpu_batch`:

1. **Non-`CV_8UC3` inputs.** `infer_batches` also accepts `CV_8UC1` crops, but
   `preprocess_gpu_batch` packs `rows*cols*3` bytes and the bilinear kernel reads 3 channels.
   The existing `inputC != 3` guard only checks the **network** input, not each crop's `cv::Mat`
   type — so a 1-channel crop would over-read the source buffer. **Fix:** a per-crop type check;
   if any crop is not `CV_8UC3`, fall back to the CPU `preprocess()` (which converts via `cvtColor`).

2. **Scratch-buffer lifetime.** `h_batch_` / `d_batch_` were raw `cudaMallocHost` / `cudaMalloc`
   pointers never released (leak at instance teardown). **Fix:** converted to the project's RAII
   wrappers `CudaUniquePtrHost<unsigned char[]>` / `CudaUniquePtr<unsigned char[]>` (as used for
   `d_depthmap_`, `h_entropy_`, …) — reassigning on grow frees the old buffer, and they are released
   with the `TrtLightnet` instance. No destructor change needed.

## Change
- `tensorrt_lightnet.hpp`: `h_batch_` / `d_batch_` → `CudaUniquePtrHost`/`CudaUniquePtr`.
- `tensorrt_lightnet.cpp`: add the per-crop `CV_8UC3` guard; grow via `make_unique_host`/`make_unique`;
  `.get()` at the three use sites. (Existing merged comments/logic left untouched.)

## Testing
- Builds clean against current `main` (`liblightnetinfer.so` links; exit 0).
- Behavior unchanged for the common `CV_8UC3` path (the parity already reported in #20 holds);
  `CV_8UC1` now routes to the CPU path instead of over-reading.

## Risk / compatibility
Low — touches only the (opt-in) `preprocess_gpu_batch` path added in #20; the CPU default and all
other code are unaffected.
